### PR TITLE
Fix bug where favorites array was holding copies of the current recipe

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,6 +70,13 @@ myFavoritesButton.addEventListener('click', displayFavorites);
 
 // Functions and Event Handlers
 
+function createFavoriteRecipe(type, dish) {
+    return {
+        type: type,
+        dish: dish,
+        }
+}
+
 function getRandomIndex() {
     return Math.floor(Math.random() * window[currentRecipe.type].length);
 }
@@ -100,7 +107,8 @@ function clearRecipe() {
 }
 
 function favoriteRecipe() {
-    favoriteRecipes.push(currentRecipe);
+    var recipe = createFavoriteRecipe(currentRecipe.type, currentRecipe.dish);
+    favoriteRecipes.push(recipe);
 }
 
 function displayFavorites() {


### PR DESCRIPTION
This is a bug fix. The favoriteRecipes array was previously set to push in the current recipe as opposed to a new favorite recipe leading the array to be filled with copies of whatever the current recipe was. Now the favoriteRecipes holds a new favorite recipe object for each recipe thats favorited.